### PR TITLE
fix: paginate projects in jira

### DIFF
--- a/provider/jira/jira.go
+++ b/provider/jira/jira.go
@@ -218,12 +218,11 @@ func (p *jiraSimple) getProjectKeys(token, cloudID string) (Values, error) {
 		CloudID:     cloudID,
 	}
 
-	response, err := p.Client.GetProjects(request)
+	values, err := p.Client.GetProjects(request)
 	if err != nil {
 		log.Errorf("jira: getting projects: %v", err)
 		return nil, err
 	}
-	values := response.Values
 
 	projectKeys := make([]Value, 0, len(values))
 	for i := range values {


### PR DESCRIPTION
Fetching projects in Jira is limited to 50 projects in a single API call. This PR introduces pagination when fetching projects so that all projects in a Jira site are fetched.