### PR TITLE
feat: update Jira options to show valid issue types per project

### DIFF
--- a/provider/jira/client.go
+++ b/provider/jira/client.go
@@ -18,7 +18,6 @@ const (
 	accessibleResourcesURL = "https://api.atlassian.com/oauth/token/accessible-resources"
 	projectSearchURL       = "https://api.atlassian.com/ex/jira/%s/rest/api/3/project/search?expand=issueTypes"
 	postIssueURL           = "https://api.atlassian.com/ex/jira/%s/rest/api/3/issue"
-	issueTypesResourceURL  = "https://api.atlassian.com/ex/jira/%s/rest/api/3/issuetype"
 )
 
 type Client struct {
@@ -209,42 +208,6 @@ func (c *Client) GetProjects(request *GetProjectsRequest) ([]Project, domain.IEr
 		req.URL = nextURL
 	}
 	return projects, nil
-}
-
-type GetIssueTypesRequest struct {
-	BearerToken string
-	CloudID     string
-}
-
-type GetIssueTypesResponse []IssueType
-
-func (c *Client) GetIssueTypes(request *GetIssueTypesRequest) (*GetIssueTypesResponse, domain.IError) {
-	req, err := http.NewRequest("GET", fmt.Sprintf(issueTypesResourceURL, request.CloudID), http.NoBody)
-	if err != nil {
-		log.Errorf("jira: failed requesting issue types: %v", err)
-		return nil, errFailedTemporary("failed to send request")
-	}
-
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", request.BearerToken))
-	req.Header.Add("Content-Type", "application/json; charset=utf-8")
-
-	resp, err := c.HTTPClient.Do(req)
-	if err != nil {
-		log.Errorf("jira: something went wrong requesting issue types: %v", err)
-		return nil, errFailedTemporary("something went wrong")
-	}
-
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
-		return nil, handleHTTPFailure(resp)
-	}
-
-	response := new(GetIssueTypesResponse)
-	if err := json.NewDecoder(resp.Body).Decode(response); err != nil {
-		log.Errorf("jira: failed decoding issue types response: %v", err)
-		return nil, errFailedPermenant("success but failed to parse response body")
-	}
-
-	return response, nil
 }
 
 func handleHTTPFailure(response *http.Response) domain.IError {

--- a/provider/jira/client.go
+++ b/provider/jira/client.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	accessibleResourcesURL = "https://api.atlassian.com/oauth/token/accessible-resources"
-	projectSearchURL       = "https://api.atlassian.com/ex/jira/%s/rest/api/3/project/search"
+	projectSearchURL       = "https://api.atlassian.com/ex/jira/%s/rest/api/3/project/search?expand=issueTypes"
 	postIssueURL           = "https://api.atlassian.com/ex/jira/%s/rest/api/3/issue"
 	issueTypesResourceURL  = "https://api.atlassian.com/ex/jira/%s/rest/api/3/issuetype"
 )
@@ -26,11 +26,12 @@ type Client struct {
 }
 
 type Project struct {
-	Expand     string `json:"expand"`
-	Self       string `json:"self"`
-	ID         string `json:"id"`
-	Key        string `json:"key"`
-	Name       string `json:"name"`
+	Expand     string      `json:"expand"`
+	Self       string      `json:"self"`
+	ID         string      `json:"id"`
+	Key        string      `json:"key"`
+	IssueTypes []IssueType `json:"issueTypes"`
+	Name       string      `json:"name"`
 	AvatarUrls struct {
 		Four8X48  string `json:"48x48"`
 		Two4X24   string `json:"24x24"`
@@ -45,15 +46,14 @@ type Project struct {
 }
 
 type IssueType struct {
-	Self             string `json:"self"`
-	ID               string `json:"id"`
-	Description      string `json:"description"`
-	IconURL          string `json:"iconUrl"`
-	Name             string `json:"name"`
-	UntranslatedName string `json:"untranslatedName"`
-	Subtask          bool   `json:"subtask"`
-	AvatarID         int    `json:"avatarId,omitempty"`
-	HierarchyLevel   int    `json:"hierarchyLevel"`
+	Self           string `json:"self"`
+	ID             string `json:"id"`
+	Description    string `json:"description"`
+	IconURL        string `json:"iconUrl"`
+	Name           string `json:"name"`
+	Subtask        bool   `json:"subtask"`
+	AvatarID       int    `json:"avatarId,omitempty"`
+	HierarchyLevel int    `json:"hierarchyLevel"`
 }
 
 type Fields struct {
@@ -208,7 +208,6 @@ func (c *Client) GetProjects(request *GetProjectsRequest) ([]Project, domain.IEr
 		}
 		req.URL = nextURL
 	}
-
 	return projects, nil
 }
 

--- a/provider/jira/jira.go
+++ b/provider/jira/jira.go
@@ -171,30 +171,6 @@ func (p *jiraSimple) getSites(token string) (Values, error) {
 	return sites, nil
 }
 
-func (p *jiraSimple) getIssueTypes(token, cloudID string) (Values, error) {
-	request := &GetIssueTypesRequest{
-		BearerToken: token,
-		CloudID:     cloudID,
-	}
-
-	response, err := p.Client.GetIssueTypes(request)
-	if err != nil {
-		log.Errorf("jira: getting issue types: %v", err)
-		return nil, err
-	}
-
-	issueTypes := make([]Value, 0, len(*response))
-	for i := range *response {
-		issueTypes = append(issueTypes,
-			Value{
-				ID:   (*response)[i].ID,
-				Name: (*response)[i].Name,
-			},
-		)
-	}
-	return issueTypes, nil
-}
-
 func (p *jiraSimple) getProjects(token, cloudID string) ([]Project, error) {
 	request := &GetProjectsRequest{
 		BearerToken: token,
@@ -208,30 +184,6 @@ func (p *jiraSimple) getProjects(token, cloudID string) ([]Project, error) {
 	}
 
 	return projects, nil
-}
-
-func (p *jiraSimple) getProjectKeys(token, cloudID string) (Values, error) {
-	request := &GetProjectsRequest{
-		BearerToken: token,
-		CloudID:     cloudID,
-	}
-
-	values, err := p.Client.GetProjects(request)
-	if err != nil {
-		log.Errorf("jira: getting projects: %v", err)
-		return nil, err
-	}
-
-	projectKeys := make([]Value, 0, len(values))
-	for i := range values {
-		projectKeys = append(projectKeys,
-			Value{
-				ID:   values[i].Key,
-				Name: values[i].Name,
-			},
-		)
-	}
-	return projectKeys, nil
 }
 
 // Payload defines the primary content payload for the JIRA provider.


### PR DESCRIPTION
Currently hermes sends valid issue types for a given atlassian site. It should instead send valid issue types for a given project.

Current options response:
```json
{
    "cloud_id": <list_of_cloud_ids>,
    "_rel": {
        "cloud_id": {
            "<cloud_id>": {
                "project_keys": <list_of_project_keys>,
                "issue_types": <list_of_issue_types>,
            }
        }
    }
}
```

New options response:
```json
{
    "cloud_id": <list_of_cloud_ids>,
    "_rel": {
        "cloud_id": {
            "<cloud_id>": {
                "project_keys": <list_of_project_keys>,
            }
        }
        "project_key": {
            "<project_id>": {
                "issue_types": <list_of_issue_types>,
            }
        }
    }
}
```