### PR TITLE
fix: exclude subtask issue types in Jira

### DIFF
--- a/provider/jira/jira.go
+++ b/provider/jira/jira.go
@@ -129,7 +129,9 @@ func (p *jiraSimple) GetOptValues(_ context.Context, opts *domain.NotifierSecret
 
 			var issueTypeValues Values
 			for _, issueType := range project.IssueTypes {
-				issueTypeValues = append(issueTypeValues, Value{ID: issueType.ID, Name: issueType.Name})
+				if !issueType.Subtask {
+					issueTypeValues = append(issueTypeValues, Value{ID: issueType.ID, Name: issueType.Name})
+				}
 			}
 
 			ProjectKeyIssueTypeMap[project.Key] = ProjectKeyInfo{IssueType: issueTypeValues}


### PR DESCRIPTION
Exclude subtask issue types in Jira options since we don't support creating subtask issue types.